### PR TITLE
hotifx: prevent step text from being cut off

### DIFF
--- a/components/ui/custom-collapsible-item/index.tsx
+++ b/components/ui/custom-collapsible-item/index.tsx
@@ -31,7 +31,7 @@ export default function CollapsibleItem({ expanded, text, stepNumber }: Step) {
       {currExpanded && (
         <View className="mt-2 flex-row justify-between items-start">
           <Text
-            className="text-white text-base flex-1 p-2 bg-transparent"
+            className="text-white text-base flex-1 bg-transparent"
           >
             { text }
           </Text>


### PR DESCRIPTION
Changelog:
- Removed padding in the steps component as it occasionally causes text to be cut off. 